### PR TITLE
Added OpenAI pip dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ In addition to Lemon AI's common set of tools, those workflow functions will als
 
 Please make sure to provide a proper workflow 'description' and provide the 'tools' in the right order to allow the correct execution of the workflow '['tool to be used first', ...]'.
 
-Users can ask the LLM to run a specific workflow for them:
+The following example uses OpenAI's API to operate the workflow, so before you start, install `openai` dependency with `pip`:
+
+```bash
+pip install openai
+```
+
+Now you can ask the LLM to run a specific workflow:
 
 ```python
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 ]
 dependencies = [
   "langchain",
-  "loguru"
+  "loguru",
+  "openai"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "langchain",
-  "loguru",
-  "openai"
+  "loguru"
 ]
 
 [project.urls]


### PR DESCRIPTION
Problem: installing langchain package doesn't include openai. But it requires it to run any OpenAI processes. This means user using lemonai for the first time will have to pip install openai separately.

<img width="973" alt="image" src="https://github.com/felixbrock/lemonai-py-client/assets/16231195/5dfbe8fc-bd75-498b-9d23-e537c067d462">
